### PR TITLE
3 Calendar test cases which are confirmed running smooth on hamachi with v1.3.

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/calendar/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/calendar/app.py
@@ -17,8 +17,11 @@ class Calendar(Base):
     _hint_swipe_to_navigate_locator = (By.ID, 'hint-swipe-to-navigate')
     _add_event_button_locator = (By.XPATH, "//a[@href='/event/add/']")
 
+    _today_display_button_locator = (By.XPATH, "//a[@href='#today']")
+    _month_display_button_locator = (By.XPATH, "//a[@href='/month/']")
     _week_display_button_locator = (By.XPATH, "//a[@href='/week/']")
     _day_display_button_locator = (By.XPATH, "//a[@href='/day/']")
+    _month_view_locator = (By.ID, 'month-view')
     _day_view_locator = (By.ID, 'day-view')
     _week_view_locator = (By.ID, 'week-view')
 
@@ -43,6 +46,13 @@ class Calendar(Base):
         new_event.wait_for_panel_to_load()
         return new_event
 
+    def tap_today_display_button(self):
+        self.marionette.find_element(*self._today_display_button_locator).tap()
+
+    def tap_month_display_button(self):
+        self.marionette.find_element(*self._month_display_button_locator).tap()
+        self.wait_for_element_displayed(*self._month_view_locator)
+
     def tap_week_display_button(self):
         self.marionette.find_element(*self._week_display_button_locator).tap()
         self.wait_for_element_displayed(*self._week_view_locator)
@@ -51,13 +61,28 @@ class Calendar(Base):
         self.marionette.find_element(*self._day_display_button_locator).tap()
         self.wait_for_element_displayed(*self._day_view_locator)
 
-    def displayed_events_in_month_view(self, date_time):
-        return self.marionette.find_element(*self._get_events_locator_in_month_view(date_time)).text
+    def tap_first_event(self, events):
+        # events index base is from 1
+        if len(events) > 1:
+            events[1].tap()
+            from gaiatest.apps.calendar.regions.event import NewEvent
+            event = NewEvent(self.marionette)
+            event.wait_for_edit_button_to_load()
+            return event
 
-    def displayed_events_in_week_view(self, date_time):
+    # NOTICE : 
+    # The returned list contains elements as [all, 1st, 2nd, 3rd,....] 
+    # Please access the event from index 1.
+    def displayed_events_in_month_view(self, date_time): 
+        return self.marionette.find_elements(*self._get_events_locator_in_month_view(date_time))
+
+    def displayed_1st_event_text_in_month_view(self, date_time):
+        return self.marionette.find_element(*self._get_events_text_locator_in_month_view(date_time)).text
+
+    def displayed_1st_event_text_in_week_view(self, date_time):
         return self.marionette.find_element(*self._get_events_locator_in_week_view(date_time)).text
 
-    def displayed_events_in_day_view(self, date_time):
+    def displayed_1st_event_text_in_day_view(self, date_time):
         return self.marionette.find_element(*self._get_events_locator_in_day_view(date_time)).text
 
     def _get_events_locator_in_day_view(self, date_time):
@@ -69,7 +94,11 @@ class Calendar(Base):
     def _get_events_locator_in_month_view(self, date_time):
         time_slot = self._get_data_hour(date_time)
         return (By.CSS_SELECTOR,
-                '#event-list section.hour-%d div.events' % time_slot)
+                '#event-list section.hour-%d div' % time_slot)
+
+    def _get_events_text_locator_in_month_view(self, date_time):
+        events_locator = self._get_events_locator_in_month_view(date_time)
+        return (events_locator[0], events_locator[1] + '.events') 
 
     def _get_events_locator_in_week_view(self, date_time):
         time_slot = self._get_data_hour(date_time)

--- a/tests/python/gaia-ui-tests/gaiatest/apps/calendar/regions/event.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/calendar/regions/event.py
@@ -12,9 +12,13 @@ class NewEvent(Calendar):
     _event_location_input_locator = (By.XPATH, "//input[@data-l10n-id='event-location']")
     _edit_event_button_locator = (By.CSS_SELECTOR, 'button.edit')
     _save_event_button_locator = (By.CSS_SELECTOR, 'button.save')
+    _delete_event_button_locator = (By.CLASS_NAME, 'delete')
 
     def wait_for_panel_to_load(self):
         self.wait_for_element_displayed(*self._event_title_input_locator)
+
+    def wait_for_edit_button_to_load(self):
+        self.wait_for_element_displayed(*self._edit_event_button_locator)
 
     def fill_event_title(self, title):
         event_title_input = self.marionette.find_element(*self._event_title_input_locator)
@@ -29,3 +33,12 @@ class NewEvent(Calendar):
     def tap_save_event(self):
         self.marionette.find_element(*self._save_event_button_locator).tap()
         self.wait_for_element_not_displayed(*self._save_event_button_locator)
+
+    def tap_edit_event(self):
+        self.marionette.find_element(*self._edit_event_button_locator).tap()
+        self.wait_for_element_not_displayed(*self._edit_event_button_locator)
+
+    def tap_delete_event(self):
+        self.marionette.find_element(*self._delete_event_button_locator).tap()
+        self.wait_for_element_not_displayed(*self._delete_event_button_locator)
+

--- a/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/manifest.ini
@@ -1,0 +1,8 @@
+[DEFAULT]
+b2g = true
+
+[test_calendar_today_date.py]
+
+[test_calendar_new_event_appears_on_all_calendar_views.py]
+
+[test_calendar_flick_through_months.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/test_calendar_flick_through_months.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/test_calendar_flick_through_months.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+from MtbfTestCase import GaiaMtbfTestCase
+from gaiatest.apps.calendar.app import Calendar
+
+
+class TestCalendar(GaiaMtbfTestCase):
+
+    def setUp(self):
+        GaiaMtbfTestCase.setUp(self)
+
+        self.today = datetime.date.today()
+        # Determine the name and the year of the next month
+        self.next_month_year = self.today.replace(day=1) + datetime.timedelta(days=32)
+
+        self.calendar = Calendar(self.marionette)
+        self.calendar.launch()
+
+    def test_calendar_flick_through_months(self):
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=937085
+
+        MONTH_YEAR_PATTERN = '%B %Y'
+
+        self.calendar.flick_to_next_month()
+        self.assertEquals(self.next_month_year.strftime(MONTH_YEAR_PATTERN),
+                          self.calendar.current_month_year)
+
+        self.calendar.flick_to_previous_month()
+        self.assertEquals(self.today.strftime(MONTH_YEAR_PATTERN), self.calendar.current_month_year)
+
+
+    def tearDown(self):
+        self.calendar.tap_today_display_button()
+        GaiaMtbfTestCase.tearDown(self)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/test_calendar_new_event_appears_on_all_calendar_views.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/test_calendar_new_event_appears_on_all_calendar_views.py
@@ -1,0 +1,67 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from datetime import datetime, timedelta
+
+from MtbfTestCase import GaiaMtbfTestCase
+from gaiatest.apps.calendar.app import Calendar
+
+
+class TestCalendar(GaiaMtbfTestCase):
+
+    def setUp(self):
+        GaiaMtbfTestCase.setUp(self)
+        
+        self.calendar = Calendar(self.marionette)
+        self.calendar.launch()
+
+    def test_that_new_event_appears_on_all_calendar_views(self):
+
+        # We get the actual time of the device
+        _seconds_since_epoch = self.marionette.execute_script("return Date.now();")
+        now = datetime.utcfromtimestamp(_seconds_since_epoch / 1000)
+
+        # We know that the default event time will be rounded up 1 hour
+        event_start_date_time = now + timedelta(hours=1)
+
+        event_title = 'Event Title %s' % str(event_start_date_time.time())
+        event_location = 'Event Location %s' % str(event_start_date_time.time())
+
+        new_event = self.calendar.tap_add_event_button()
+
+        # create a new event
+        new_event.fill_event_title(event_title)
+        new_event.fill_event_location(event_location)
+
+        new_event.tap_save_event()
+
+        # assert that the event is displayed as expected in month view
+        self.assertIn(event_title, self.calendar.displayed_1st_event_text_in_month_view(event_start_date_time))
+        self.assertIn(event_location, self.calendar.displayed_1st_event_text_in_month_view(event_start_date_time))
+
+        # switch to the week display
+        self.calendar.tap_week_display_button()
+        self.assertIn(event_title, self.calendar.displayed_1st_event_text_in_week_view(event_start_date_time))
+
+        # switch to the day display
+        self.calendar.tap_day_display_button()
+        self.assertIn(event_title, self.calendar.displayed_1st_event_text_in_day_view(event_start_date_time))
+        self.assertIn(event_location, self.calendar.displayed_1st_event_text_in_day_view(event_start_date_time))
+
+        # for clean up
+        self.event_start_date_time = event_start_date_time
+
+    def tearDown(self):
+        # Clean up
+        self.calendar.tap_month_display_button()
+        events = self.calendar.displayed_events_in_month_view(self.event_start_date_time)
+        # Usually, only has one event and it's hard-coded.
+        # If necessary, fix it by reloading and enumerating events.
+
+        # The event index is from 1, not 0.
+        first_event = self.calendar.tap_first_event(events)
+        first_event.tap_edit_event()
+        first_event.tap_delete_event()
+
+        GaiaMtbfTestCase.tearDown(self)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/test_calendar_today_date.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/mtbf/calendar/test_calendar_today_date.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from datetime import datetime
+
+from MtbfTestCase import GaiaMtbfTestCase
+from gaiatest.apps.calendar.app import Calendar
+
+
+class TestCalendar(GaiaMtbfTestCase):
+
+    def setUp(self):
+        GaiaMtbfTestCase.setUp(self)
+
+        self.calendar = Calendar(self.marionette)
+        self.calendar.launch()
+
+    def test_check_today_date(self):
+
+        # We get the actual time of the device
+        _seconds_since_epoch = self.marionette.execute_script("return Date.now();")
+        now = datetime.utcfromtimestamp(_seconds_since_epoch / 1000)
+
+        self.assertEquals(now.strftime('%B %Y'), self.calendar.current_month_year)
+        self.assertIn(now.strftime('%a %b %d %Y'), self.calendar.current_month_day)
+
+    def tearDown(self):
+        
+        GaiaMtbfTestCase.tearDown(self)


### PR DESCRIPTION
1. calendar app modified
   - add today display button and tap method (clean-up issue)
   - add month_view_locator (clean-up issue)
   - add tap_first_event to enter the event edit page (clean-up issue)
   - rename displayed_events_in_xxx_view
      to displayed_1st_event_text_in_xxx_view for reality
   - add new displayed_events_in_month_view method,
     it's for real events(clean-up issue)
   - add _get_events_text_locator_in_month_view for the event_text usage
   - modify _get_events_locator_in_month_view for real events, not event text
2. calendar.event modified
   - add edit button, its tap and wait method (clean-up issue)
   - add delete button and tap method (clean-up issue)
